### PR TITLE
Update url for img controller

### DIFF
--- a/bitnami-sealed-controller/controller.yaml
+++ b/bitnami-sealed-controller/controller.yaml
@@ -209,7 +209,7 @@ spec:
         command:
         - controller
         env: []
-        image: quay.io/bitnami/sealed-secrets-controller:v0.16.0
+        image: docker.io/bitnami/sealed-secrets-controller:v0.16.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Updated the URL for the bitnami sealed-secrets-controller redirecting to docker instead of quay. 
Linked issue: https://github.com/bitnami-labs/sealed-secrets/issues/822